### PR TITLE
Turning compatible with Django 1.6

### DIFF
--- a/mezzanine_events/urls.py
+++ b/mezzanine_events/urls.py
@@ -1,5 +1,4 @@
-
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 from django.contrib import admin
 from . import views
 


### PR DESCRIPTION
django.conf.urls.defaults has been removed on Django 1.6.
