### PR TITLE
Hide Speaker and RSVP labels when empty

### DIFF
--- a/mezzanine_events/templates/pages/event.html
+++ b/mezzanine_events/templates/pages/event.html
@@ -27,6 +27,7 @@ From {{page.event.date}}, {{page.event.start_time}} to {{page.event.end_date}}, 
 			</a>
 		</address>
 	</div>
+	{% if page.event.speakers_list %}
 	<div class="span4">
 		<b>Speakers</b>
 		<address>
@@ -37,12 +38,15 @@ From {{page.event.date}}, {{page.event.start_time}} to {{page.event.end_date}}, 
 			</ul>
 		</address>
 	</div>
+	{% endif %}
+	{% if page.event.rsvp %}	
 	<div class="span4">
 		<b>RSVP</b>
 		<p>
 			{{page.event.rsvp|linebreaksbr|link_emails}}
 		</p>
 	</div>
+	{% endif %}
 </div>
 
 {{page.event.content|richtext_filter|safe}}


### PR DESCRIPTION
Since I have several events that don't make use of the speaker and rsvp labels and they're not required fields, I made display of their divs conditional on having data and thought it might be useful to others.
