### PR TITLE
fixed end_time comparison bug

### DIFF
--- a/mezzanine_events/models.py
+++ b/mezzanine_events/models.py
@@ -42,7 +42,7 @@ class Event(Page, RichText):
         if self.date > self.end_date:
             raise ValidationError("Start date must be sooner than end date.")
 
-        if self.date == self.end_date and self.start_time > self.end_time:
+        if self.start_time and self.end_time and self.date == self.end_date and self.start_time > self.end_time:
             raise ValidationError("Start time must be sooner than end time.")
 
         if self.lat and not self.lon:


### PR DESCRIPTION
Fixes TypeError:

```
can't compare datetime.time to NoneType
```

Reproduce by defining a ModelForm and validating a record with start_time provided but no end_time.
